### PR TITLE
wayne-common: init: stop creating fota dir

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -344,10 +344,6 @@ on post-fs-data
     mkdir /data/shared 0755
     chown system system /data/shared
 
-    #Create directory for FOTA
-    mkdir /data/fota 0771
-    chown system system /data/fota
-
     #Create directory for hostapd
     mkdir /data/hostapd 0770 system wifi
 


### PR DESCRIPTION
* Fota is used in stock there is no use of creating that here. (Little house keeping?)